### PR TITLE
use env command to locate php interpreter

### DIFF
--- a/validate_m2_package.php
+++ b/validate_m2_package.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
  * Copyright © 2016 Magento. All rights reserved.


### PR DESCRIPTION
The script fails to run in every environment where PHP is not located in `/usr/bin/php`. Popular examples include the PHP Docker images:

```
# /usr/bin/php -v
bash: /usr/bin/php: No such file or directory

# which php
/usr/local/bin/php

# /usr/bin/env php -v
PHP 7.0.22 (cli) (built: Aug  3 2017 22:16:07) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
```

Updating the shebang to use the `env` command establishes script portability.